### PR TITLE
Lockdown aws-ia/vpc version

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -65,3 +65,10 @@ terraform taint module.instances[\"us-west-2c\"].aws_instance.polygon_edge_insta
 terraform taint module.instances[\"us-west-2d\"].aws_instance.polygon_edge_instance
 terraform apply
 ```
+
+### Deployment
+
+VPC must be created beforehand, as the instances are deployed using a loop which must know all
+AZ names in advance.
+
+To do this, simply run `terraform apply -target=module.vpc` and then `terraform apply` after it.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ terraform taint module.instances[\"us-west-2d\"].aws_instance.polygon_edge_insta
 terraform apply
 ```
 
+### Deployment
+
+VPC must be created beforehand, as the instances are deployed using a loop which must know all
+AZ names in advance.
+
+To do this, simply run `terraform apply -target=module.vpc` and then `terraform apply` after it.
+
 ## Requirements
 
 | Name | Version |
@@ -92,7 +99,7 @@ terraform apply
 | <a name="module_s3"></a> [s3](#module\_s3) | terraform-aws-modules/s3-bucket/aws | >= 3.3.0 |
 | <a name="module_security"></a> [security](#module\_security) | ./modules/security | n/a |
 | <a name="module_user_data"></a> [user\_data](#module\_user\_data) | ./modules/user-data | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 1.4.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | = 1.4.1 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "aws-ia/vpc/aws"
-  version = ">= 1.4.1"
+  version = "= 1.4.1"
 
   name       = var.vpc_name
   cidr_block = var.vpc_cidr_block


### PR DESCRIPTION
Since `aws-ia/vpc/aws` module has been bumped to `v2.1.0` this deploy does not work, as the `vpc` module  `private_subnet_attributes_by_az` output returns `private/<az_name>` instead of just `<az_name>` .

This PR locks down the `aws-ia/vpc/aws` module version to alleviate this issue, and in the future we'll work on rewriting the scripts to support higher versions of `aws-ia/vpc/aws` module.