### PR TITLE
Removed root module variables in favor of implied context

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ process itself.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | < 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0, < 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.27.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.2.2 |

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ process itself.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | < 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.27.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.2.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >=3.1.1 |
 
 ## Providers
@@ -107,15 +109,16 @@ process itself.
 |------|------|
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.genesis_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.genesis_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [null_data_source.downloaded_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account number | `string` | n/a | yes |
 | <a name="input_alb_ssl_certificate"></a> [alb\_ssl\_certificate](#input\_alb\_ssl\_certificate) | SSL certificate ARN for JSON-RPC loadblancer | `string` | n/a | yes |
 | <a name="input_premine"></a> [premine](#input\_premine) | Premine the accounts with the specified ammount. Format: account:ammount,account:ammount | `string` | n/a | yes |
 | <a name="input_alb_sec_gr_name_tag"></a> [alb\_sec\_gr\_name\_tag](#input\_alb\_sec\_gr\_name\_tag) | External security group name tag | `string` | `"Polygon Edge External"` | no |
@@ -149,7 +152,6 @@ process itself.
 | <a name="input_pos"></a> [pos](#input\_pos) | Use PoS IBFT consensus | `bool` | `false` | no |
 | <a name="input_price_limit"></a> [price\_limit](#input\_price\_limit) | Sets minimum gas price limit to enforce for acceptance into the pool | `string` | `""` | no |
 | <a name="input_prometheus_address"></a> [prometheus\_address](#input\_prometheus\_address) | Enable Prometheus API | `string` | `""` | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"us-west-2"` | no |
 | <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | Name prefix for new S3 bucket | `string` | `"polygon-edge-shared-"` | no |
 | <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | Delete S3 bucket on destroy, even if the bucket is not empty | `bool` | `true` | no |
 | <a name="input_s3_key_name"></a> [s3\_key\_name](#input\_s3\_key\_name) | Name of the file in S3 that will hold configuration | `string` | `"chain-config"` | no |

--- a/data.tf
+++ b/data.tf
@@ -6,6 +6,8 @@ data "null_data_source" "downloaded_package" {
 }
 
 data "aws_availability_zones" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
 
 
 data "aws_iam_policy_document" "genesis_s3" {
@@ -32,7 +34,7 @@ data "aws_iam_policy_document" "genesis_ssm" {
       "ssm:GetParametersByPath"
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.ssm_parameter_id}/*"
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.ssm_parameter_id}/*"
     ]
 
   }

--- a/main.tf
+++ b/main.tf
@@ -48,10 +48,10 @@ module "security" {
   source = "./modules/security"
 
   vpc_id                   = module.vpc.vpc_attributes.id
-  account_id               = var.account_id
+  account_id               = data.aws_caller_identity.current.account_id
   s3_shared_bucket_name    = module.s3.s3_bucket_id
   ssm_parameter_id         = var.ssm_parameter_id
-  region                   = var.region
+  region                   = data.aws_region.current.name
   internal_sec_gr_name_tag = var.internal_sec_gr_name_tag
   alb_sec_gr_name_tag      = var.alb_sec_gr_name_tag
   lambda_function_name     = var.lambda_function_name
@@ -84,7 +84,7 @@ module "user_data" {
   node_name = "${var.node_name_prefix}-${each.value}"
 
   assm_path      = var.ssm_parameter_id
-  assm_region    = var.region
+  assm_region    = data.aws_region.current.name
   s3_bucket_name = module.s3.s3_bucket_id
   s3_key_name    = var.s3_key_name
   total_nodes    = length(module.vpc.private_subnet_attributes_by_az)

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = "< 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,6 +8,14 @@ terraform {
     awscc = {
       source  = "hashicorp/awscc"
       version = ">= 0.27.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.2.3"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.2.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "< 1.3.0"
+  required_version = ">= 1.1.0, < 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -28,24 +28,10 @@ variable "s3_key_name" {
 }
 
 # SECURITY
-variable "account_id" {
-  description = "The AWS account number"
-  type        = string
-}
 variable "ssm_parameter_id" {
   description = "The id that will be used for storing and fetching from SSM Parameter Store"
   type        = string
   default     = "polygon-edge-validators"
-}
-variable "region" {
-  description = "AWS region"
-  type        = string
-  default     = "us-west-2"
-  # must deploy in a 4 AZ region
-  validation {
-    condition     = contains(["us-west-2", "us-east-1", "ap-northeast-2", "ap-northeast-1"], var.region)
-    error_message = "The deployment must be done in 4 AZ region."
-  }
 }
 variable "internal_sec_gr_name_tag" {
   type        = string


### PR DESCRIPTION
# Overview
We can imply the target `account_id` and `region` since users are expected to drive the module with an AWS caller identity or credentials. It should be the user's responsibility to configure their AWS provider accordingly, to avoid over-extension. 

This change does remove the variable validation to check for the explicit 4 availability zone requirement (which can be addressed in a future PR). The resulting behavior should be acceptable, since it fails downstream validations during the `terraform plan` phase. The resulting errors are a bit  vague in the root cause vs the explicit variable validation logic.

Output of `terraform plan` with the appropriate variables in `eu-central-1`, where as of today, has less than 4 availability zones. 

``` 
Error: Invalid function argument
│ 
│   on main.tf line 30, in locals:
│   30:   azs             = slice(data.aws_availability_zones.current.names, 0, 4)
│ 
│ Invalid value for "end_index" parameter: end index must not be greater than the length of the list.
╵
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/vpc/data.tf line 2, in locals:
│    2:   azs = slice(data.aws_availability_zones.current.names, 0, var.az_count)
│     ├────────────────
│     │ var.az_count is 4
│ 
│ Invalid value for "end_index" parameter: end index must not be greater than the length of the list.
```

## Breaking Changes
- The root module no longer accepts `account_id` and `region` variables, as they will be implied from the user's configured provider. 