### PR TITLE
Replace deprecated provider hashicorp/template

### DIFF
--- a/modules/user-data/main.tf
+++ b/modules/user-data/main.tf
@@ -1,32 +1,33 @@
-data "template_file" "polygon_edge_node" {
-  template = file("${path.module}/scripts/polygon_edge_node.tpl")
+locals {
+  polygon_edge_node = templatefile(
+    "${path.module}/scripts/polygon_edge_node.tpl",
+    {
+      "polygon_edge_dir"     = var.polygon_edge_dir
+      "ebs_device"           = var.ebs_device
+      "node_name"            = var.node_name
+      "assm_path"            = var.assm_path
+      "assm_region"          = var.assm_region
+      "total_nodes"          = var.total_nodes
+      "s3_bucket_name"       = var.s3_bucket_name
+      "s3_key_name"          = var.s3_key_name
+      "lambda_function_name" = var.lambda_function_name
 
-  vars = {
-    "polygon_edge_dir"     = var.polygon_edge_dir
-    "ebs_device"           = var.ebs_device
-    "node_name"            = var.node_name
-    "assm_path"            = var.assm_path
-    "assm_region"          = var.assm_region
-    "total_nodes"          = var.total_nodes
-    "s3_bucket_name"       = var.s3_bucket_name
-    "s3_key_name"          = var.s3_key_name
-    "lambda_function_name" = var.lambda_function_name
+      "premine"             = var.premine
+      "chain_name"          = var.chain_name
+      "chain_id"            = var.chain_id
+      "pos"                 = var.pos
+      "epoch_size"          = var.epoch_size
+      "block_gas_limit"     = var.block_gas_limit
+      "max_validator_count" = var.max_validator_count
+      "min_validator_count" = var.min_validator_count
+      "consensus"           = var.consensus
+    }
+  )
 
-    "premine"             = var.premine
-    "chain_name"          = var.chain_name
-    "chain_id"            = var.chain_id
-    "pos"                 = var.pos
-    "epoch_size"          = var.epoch_size
-    "block_gas_limit"     = var.block_gas_limit
-    "max_validator_count" = var.max_validator_count
-    "min_validator_count" = var.min_validator_count
-    "consensus"           = var.consensus
-  }
-}
 
-data "template_file" "polygon_edge_server" {
-  template = file("${path.module}/scripts/polygon_edge_server.tpl")
-  vars = {
+  polygon_edge_server = templatefile(
+  "${path.module}/scripts/polygon_edge_server.tpl",
+  {
     "polygon_edge_dir"   = var.polygon_edge_dir
     "s3_bucket_name"     = var.s3_bucket_name
     "prometheus_address" = var.prometheus_address
@@ -37,19 +38,22 @@ data "template_file" "polygon_edge_server" {
     "max_slots"          = var.max_slots
     "block_time"         = var.block_time
   }
+  )
 }
 
-data "template_cloudinit_config" "polygon_edge" {
+data "cloudinit_config" "polygon_edge" {
   gzip          = true
   base64_encode = true
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.polygon_edge_node.rendered
+    content      = local.polygon_edge_node
+    filename     = "01-polygon-edge-node.sh"
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.polygon_edge_server.rendered
+    content      = local.polygon_edge_server
+    filename     = "02-polygon-edge-server.sh"
   }
 }

--- a/modules/user-data/main.tf
+++ b/modules/user-data/main.tf
@@ -26,18 +26,18 @@ locals {
 
 
   polygon_edge_server = templatefile(
-  "${path.module}/scripts/polygon_edge_server.tpl",
-  {
-    "polygon_edge_dir"   = var.polygon_edge_dir
-    "s3_bucket_name"     = var.s3_bucket_name
-    "prometheus_address" = var.prometheus_address
-    "block_gas_target"   = var.block_gas_target
-    "nat_address"        = var.nat_address
-    "dns_name"           = var.dns_name
-    "price_limit"        = var.price_limit
-    "max_slots"          = var.max_slots
-    "block_time"         = var.block_time
-  }
+    "${path.module}/scripts/polygon_edge_server.tpl",
+    {
+      "polygon_edge_dir"   = var.polygon_edge_dir
+      "s3_bucket_name"     = var.s3_bucket_name
+      "prometheus_address" = var.prometheus_address
+      "block_gas_target"   = var.block_gas_target
+      "nat_address"        = var.nat_address
+      "dns_name"           = var.dns_name
+      "price_limit"        = var.price_limit
+      "max_slots"          = var.max_slots
+      "block_time"         = var.block_time
+    }
   )
 }
 

--- a/modules/user-data/outputs.tf
+++ b/modules/user-data/outputs.tf
@@ -1,4 +1,4 @@
 output "polygon_edge_node" {
-  value       = data.template_cloudinit_config.polygon_edge.rendered
+  value       = data.cloudinit_config.polygon_edge.rendered
   description = "Base64 rendered polygon edge node user-init data"
 }

--- a/modules/user-data/versions.tf
+++ b/modules/user-data/versions.tf
@@ -6,8 +6,8 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.22.0"
     }
-    template = {
-      source  = "hashicorp/template"
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
       version = "2.2.0"
     }
   }


### PR DESCRIPTION
PR replaces deprecated Hashicorp template provider https://registry.terraform.io/providers/hashicorp/template/latest/docs

Also fixed the provider issue with darwin_arm64 https://github.com/hashicorp/terraform/issues/30055 and terraform now works with macOS arm.